### PR TITLE
Add method removeRelation

### DIFF
--- a/src/DynamicRelations.php
+++ b/src/DynamicRelations.php
@@ -3,7 +3,6 @@
 namespace Imanghafoori\Relativity;
 
 use Illuminate\Support\Str;
-use Imanghafoori\Relativity\Exceptions;
 
 trait DynamicRelations
 {
@@ -23,7 +22,7 @@ trait DynamicRelations
 
     public static function removeRelation(string $relationName)
     {
-        if (!isset(static::$dynamicRelations[$relationName])) {
+        if (! isset(static::$dynamicRelations[$relationName])) {
             throw new Exceptions\UndefinedDynamicRelationException($relationName);
         }
 

--- a/src/DynamicRelations.php
+++ b/src/DynamicRelations.php
@@ -3,6 +3,7 @@
 namespace Imanghafoori\Relativity;
 
 use Illuminate\Support\Str;
+use Imanghafoori\Relativity\Exceptions;
 
 trait DynamicRelations
 {
@@ -18,6 +19,15 @@ trait DynamicRelations
     public function hasDynamicRelation(string $relation)
     {
         return isset(static::$dynamicRelations[$relation]);
+    }
+
+    public static function removeRelation(string $relationName)
+    {
+        if (!isset(static::$dynamicRelations[$relationName])) {
+            throw new Exceptions\UndefinedDynamicRelationException($relationName);
+        }
+
+        unset(static::$dynamicRelations[$relationName]);
     }
 
     public static function defineRelation($relationType, $relationName, $data, $constraints)

--- a/src/Exceptions/UndefinedDynamicRelationException.php
+++ b/src/Exceptions/UndefinedDynamicRelationException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Imanghafoori\Relativity\Exceptions;
+
+use Exception;
+
+class UndefinedDynamicRelationException extends Exception
+{
+    public function __construct(string $relation)
+    {
+        $this->message = sprintf("Undefined dynamic relation '%s' called", $relation);
+    }
+}

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Imanghafoori\Relativity\Tests;
+
+use Imanghafoori\Relativity\Tests\RelativeModels\User;
+use Imanghafoori\Relativity\Tests\RelativeModels\Comment;
+use Imanghafoori\Relativity\Exceptions\UndefinedDynamicRelationException;
+
+class BasicTest extends TestCase
+{
+    public function test_remove_relation()
+    {
+        User::has_many('comments', Comment::class);
+        $this->assertTrue((new User)->hasDynamicRelation('comments'));
+        $this->assertEquals(1, count((new User)->getDynamicRelations()));
+
+        User::removeRelation('comments');
+        $this->assertFalse((new User)->hasDynamicRelation('comments'));
+        $this->assertEquals(0, count((new User)->getDynamicRelations()));
+    }
+
+    public function test_exception_undefined_relation()
+    {
+        $this->expectException(UndefinedDynamicRelationException::class);
+        User::removeRelation('comments');
+    }
+}


### PR DESCRIPTION
A new method to remove previously defined relationships.

I don't know if you prefer others name such as `remove`, `unset` or `delete`, i will rename if you prefer another one